### PR TITLE
Client call fixes

### DIFF
--- a/UKFast.API.Client.SafeDNS.Tests/Operations/TemplateOperationsTests.cs
+++ b/UKFast.API.Client.SafeDNS.Tests/Operations/TemplateOperationsTests.cs
@@ -110,7 +110,6 @@ namespace UKFast.API.Client.SafeDNS.Tests.Operations
             };
 
             IUKFastSafeDNSClient client = Substitute.For<IUKFastSafeDNSClient>();
-            await client.PatchAsync("/safedns/v1/templates/123", req);
 
             var ops = new TemplateOperations<Template>(client);
             await ops.UpdateTemplateAsync(123, req);
@@ -129,7 +128,6 @@ namespace UKFast.API.Client.SafeDNS.Tests.Operations
         public async Task DeleteTemplateAsync_ValidParameters_ExpectedClientCall()
         {
             IUKFastSafeDNSClient client = Substitute.For<IUKFastSafeDNSClient>();
-            await client.DeleteAsync("/safedns/v1/templates/123");
 
             var ops = new TemplateOperations<Template>(client);
             await ops.DeleteTemplateAsync(123);

--- a/UKFast.API.Client.SafeDNS.Tests/Operations/TemplateRecordOperationsTests.cs
+++ b/UKFast.API.Client.SafeDNS.Tests/Operations/TemplateRecordOperationsTests.cs
@@ -133,7 +133,6 @@ namespace UKFast.API.Client.SafeDNS.Tests.Operations
             };
 
             IUKFastSafeDNSClient client = Substitute.For<IUKFastSafeDNSClient>();
-            await client.PatchAsync("/safedns/v1/templates/123/records/456", req);
 
             var ops = new TemplateRecordOperations<Record>(client);
             await ops.UpdateRecordAsync(123, 456, req);
@@ -159,7 +158,6 @@ namespace UKFast.API.Client.SafeDNS.Tests.Operations
         public async Task DeleteTemplateRecordAsync_ValidParameters_ExpectedClientCall()
         {
             IUKFastSafeDNSClient client = Substitute.For<IUKFastSafeDNSClient>();
-            await client.DeleteAsync("/safedns/v1/templates/123/records/456");
 
             var ops = new TemplateRecordOperations<Record>(client);
             await ops.DeleteRecordAsync(123, 456);

--- a/UKFast.API.Client.SafeDNS.Tests/Operations/ZoneOperationsTests .cs
+++ b/UKFast.API.Client.SafeDNS.Tests/Operations/ZoneOperationsTests .cs
@@ -110,7 +110,6 @@ namespace UKFast.API.Client.SafeDNS.Tests.Operations
             };
 
             IUKFastSafeDNSClient client = Substitute.For<IUKFastSafeDNSClient>();
-            await client.PatchAsync("/safedns/v1/zones/example.com", req);
 
             var ops = new ZoneOperations<Zone>(client);
             await ops.UpdateZoneAsync("example.com", req);
@@ -129,7 +128,6 @@ namespace UKFast.API.Client.SafeDNS.Tests.Operations
         public async Task DeleteZoneAsync_ValidParameters_ExpectedClientCall()
         {
             IUKFastSafeDNSClient client = Substitute.For<IUKFastSafeDNSClient>();
-            await client.DeleteAsync("/safedns/v1/zones/example.com");
 
             var ops = new ZoneOperations<Zone>(client);
             await ops.DeleteZoneAsync("example.com");

--- a/UKFast.API.Client.SafeDNS.Tests/Operations/ZoneRecordOperationsTests.cs
+++ b/UKFast.API.Client.SafeDNS.Tests/Operations/ZoneRecordOperationsTests.cs
@@ -25,7 +25,7 @@ namespace UKFast.API.Client.SafeDNS.Tests.Operations
             };
 
             IUKFastSafeDNSClient client = Substitute.For<IUKFastSafeDNSClient>();
-            client.PostAsync<Record>("/safedns/v1/zones/example.com/records", Arg.Is<CreateRecordRequest>(x => x.Name == "test.example.com")).Returns(new Record()
+            client.PostAsync<Record>("/safedns/v1/zones/example.com/records", req).Returns(new Record()
             {
                 ID = 123
             });
@@ -133,7 +133,6 @@ namespace UKFast.API.Client.SafeDNS.Tests.Operations
             };
 
             IUKFastSafeDNSClient client = Substitute.For<IUKFastSafeDNSClient>();
-            await client.PatchAsync("/safedns/v1/zones/example.com/records/123", req);
 
             var ops = new ZoneRecordOperations<Record>(client);
             await ops.UpdateRecordAsync("example.com", 123, req);
@@ -159,7 +158,6 @@ namespace UKFast.API.Client.SafeDNS.Tests.Operations
         public async Task DeleteZoneRecordAsync_ValidParameters_ExpectedClientCall()
         {
             IUKFastSafeDNSClient client = Substitute.For<IUKFastSafeDNSClient>();
-            await client.DeleteAsync("/safedns/v1/zones/example.com/records/123");
 
             var ops = new ZoneRecordOperations<Record>(client);
             await ops.DeleteRecordAsync("example.com", 123);

--- a/UKFast.API.Client.SafeDNS/Operations/TemplateOperations.cs
+++ b/UKFast.API.Client.SafeDNS/Operations/TemplateOperations.cs
@@ -44,7 +44,7 @@ namespace UKFast.API.Client.SafeDNS.Operations
                 throw new Client.Exception.UKFastClientValidationException("Invalid template id");
             }
 
-            await this.Client.PatchAsync<T>($"/safedns/v1/templates/{templateID}", req);
+            await this.Client.PatchAsync($"/safedns/v1/templates/{templateID}", req);
         }
 
         public async Task DeleteTemplateAsync(int templateID)

--- a/UKFast.API.Client.SafeDNS/Operations/TemplateRecordOperations.cs
+++ b/UKFast.API.Client.SafeDNS/Operations/TemplateRecordOperations.cs
@@ -76,7 +76,7 @@ namespace UKFast.API.Client.SafeDNS.Operations
                 throw new Client.Exception.UKFastClientValidationException("Invalid record id");
             }
 
-            await this.Client.DeleteAsync<T>($"/safedns/v1/templates/{templateID}/records/{recordID}");
+            await this.Client.DeleteAsync($"/safedns/v1/templates/{templateID}/records/{recordID}");
         }
     }
 }

--- a/UKFast.API.Client.SafeDNS/Operations/ZoneRecordOperations.cs
+++ b/UKFast.API.Client.SafeDNS/Operations/ZoneRecordOperations.cs
@@ -77,7 +77,7 @@ namespace UKFast.API.Client.SafeDNS.Operations
                 throw new Client.Exception.UKFastClientValidationException("Invalid record id");
             }
 
-            await this.Client.GetAsync<T>($"/safedns/v1/zones/{zoneName}/records/{recordID}");
+            await this.Client.DeleteAsync($"/safedns/v1/zones/{zoneName}/records/{recordID}");
         }
     }
 }


### PR DESCRIPTION
This PR fixes various issues with client calls and tests for these calls. Notably, the HTTP method used for deleting zone records was incorrect. This PR fixes this.